### PR TITLE
Fix issue #1 by updating Example to latest Keras API

### DIFF
--- a/Example/callbacks.py
+++ b/Example/callbacks.py
@@ -3,6 +3,12 @@ from keras.callbacks import Callback
 from keras import backend as K
 from keras import models
 
+def standardize_X(X):
+    if type(X) == list:
+        return X
+    else:
+        return [X]
+
 class ModelTest(Callback):
     ''' Test model at the end of every X epochs.
 
@@ -61,9 +67,10 @@ class ModelTest(Callback):
             - [Dropout: A simple way to prevent neural networks from overfitting](http://jmlr.org/papers/v15/srivastava14a.html)
             - [Dropout as a Bayesian Approximation: Representing Model Uncertainty in Deep Learning](http://arxiv.org/abs/1506.02142)
         '''
-        X = models.standardize_X(X)
+        X = standardize_X(X)
         if self._predict_stochastic is None: # we only get self.model after init
-        	self._predict_stochastic = K.function([self.model.X_test], [self.model.y_train])
+        	self._predict_stochastic = K.function([self.model.inputs[0]], [self.model.outputs[0]],
+                                                      givens={K.learning_phase(): np.uint8(1)})
         return self.model._predict_loop(self._predict_stochastic, X, batch_size, verbose)[0]
 
 

--- a/Example/sentiment_lstm_regression.py
+++ b/Example/sentiment_lstm_regression.py
@@ -49,6 +49,11 @@ dataset = loader(init_seed, maxlen, nb_words, skip_top, test_split)
 X_train, X_test, Y_train, Y_test = dataset.X_train, dataset.X_test, dataset.Y_train, dataset.Y_test
 mean_y_train, std_y_train = dataset.mean_y_train, dataset.std_y_train
 
+X_train = np.asarray(X_train)
+X_test  = np.asarray(X_test)
+Y_train = np.asarray(Y_train)
+Y_test  = np.asarray(Y_test)
+
 # Set seed:
 np.random.seed(global_seed)
 


### PR DESCRIPTION
Fix issue #1 by updating the sentiment LSTM in the Example folder to use the latest Keras API. Uses the Theano backend to fix self._predict_stochastic.

Can be tested by inserting `print(str(MC_model_output))` after line 87 of callbacks.py and comparing the difference between `K.learning_phase(): np.uint8(1)` and `K.learning_phase(): np.uint8(0)`
to see the difference between deterministic test-phase dropout and MC dropout.
